### PR TITLE
include missing lib `stdint.h`

### DIFF
--- a/include/simpletext.h
+++ b/include/simpletext.h
@@ -26,6 +26,7 @@ SOFTWARE.
 #pragma once
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 


### PR DESCRIPTION
include missing lib `stdint.h` to resolve the `uint8_t` error.